### PR TITLE
feat: add make install for dependency installation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,14 @@
       ],
       "depNameTemplate": "python",
       "datasourceTemplate": "python-version"
+    },
+    {
+      "fileMatch": ["^Makefile$", "^Dockerfile$", ".github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "pip install poetry==(?<currentValue>[\\d.]+)"
+      ],
+      "depNameTemplate": "poetry",
+      "datasourceTemplate": "pypi"
     }
   ]  
 } 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: lint test
+.PHONY: install lint test
+
+install:
+	@echo "Installing dependencies..."
+	poetry install
 
 lint:
 	@echo "Running black..."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 setup:
 	@echo "Setting up development environment..."
-	@command -v poetry >/dev/null 2>&1 || (echo "Installing Poetry..." && pip install poetry)
+	@command -v poetry >/dev/null 2>&1 || (echo "Installing Poetry..." && pip install poetry==2.1.1)
 	@echo "Installing dependencies..."
 	poetry install
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: install lint test
+.PHONY: setup install lint test
+
+setup:
+	@echo "Setting up development environment..."
+	@command -v poetry >/dev/null 2>&1 || (echo "Installing Poetry..." && pip install poetry)
+	@echo "Installing dependencies..."
+	poetry install
 
 install:
 	@echo "Installing dependencies..."


### PR DESCRIPTION
## 概要
`make install` コマンドを追加し、依存関係のインストールを簡単に行えるようにしました。

## 変更内容
- Makefile に `install` ターゲットを追加
- `poetry install` で依存関係をインストール
- `.PHONY` に `install` を追加

## 使い方
```bash
make install
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/takak2166/kashiwaas/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
