### PR TITLE
Weekly/Daily レポートを KashiwaaS と同様の Block Kit markdown で投稿

### DIFF
--- a/src/bot/formatter.py
+++ b/src/bot/formatter.py
@@ -99,9 +99,11 @@ def format_top_posts_with_reactions(posts: List[Dict[str, Any]]) -> str:
         if len(message_text) > 100:
             message_text = message_text[:100] + "..."
 
+        # `[` / `]` would break GFM link syntax in Block Kit markdown blocks
+        label = message_text.replace("[", " ").replace("]", " ")
         slack_link = post["slack_link"]
 
-        formatted_post = f"{i}. <{slack_link}|{message_text}> ({total_reactions} reactions)"
+        formatted_post = f"{i}. [{label}]({slack_link}) ({total_reactions} reactions)"
         formatted_posts.append(formatted_post)
 
     return "\n\n".join(formatted_posts)

--- a/src/bot/kashiwaas.py
+++ b/src/bot/kashiwaas.py
@@ -26,6 +26,7 @@ from src.cursor.client import (
     CursorClient,
     CursorTimeoutError,
 )
+from src.slack import markdown_blocks as _slack_md
 from src.utils.config import AppConfig, ConfigError, apply_dotenv, load_config
 from src.utils.logger import get_logger
 
@@ -33,10 +34,13 @@ logger = get_logger(__name__)
 
 _extract_question = extract_question  # tests import from kashiwaas
 
-SLACK_MESSAGE_MAX_LENGTH = 4000
-# Block Kit markdown block: standard Markdown in `text` (Slack converts for display).
-# https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
-SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12000
+# Re-export for tests (implementation lives in src.slack.markdown_blocks)
+SLACK_MESSAGE_MAX_LENGTH = _slack_md.SLACK_MESSAGE_MAX_LENGTH
+SLACK_MARKDOWN_BLOCK_TEXT_MAX = _slack_md.SLACK_MARKDOWN_BLOCK_TEXT_MAX
+_split_message = _slack_md.split_slack_message_text
+_fallback_notification_text = _slack_md.fallback_notification_text
+_say_markdown_chunks = _slack_md.say_markdown_chunks
+
 # Deduplicate by (channel, event_ts): skip processing if we already handled this event (e.g. Slack retry).
 PROCESSED_EVENT_TTL_SECONDS = 300  # 5 minutes
 _processed_events: dict[tuple[str, str], float] = {}
@@ -128,51 +132,6 @@ def create_app(cfg: AppConfig) -> App:
 def _fingerprint_text(text: str) -> str:
     normalized = text.replace("\r\n", "\n").rstrip()
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-
-
-def _split_message(text: str, max_length: int = SLACK_MESSAGE_MAX_LENGTH) -> list[str]:
-    """Split a long message into chunks respecting Slack's character limit."""
-    if len(text) <= max_length:
-        return [text]
-
-    chunks = []
-    while text:
-        if len(text) <= max_length:
-            chunks.append(text)
-            break
-
-        split_pos = text.rfind("\n", 0, max_length)
-        if split_pos == -1:
-            split_pos = text.rfind(" ", 0, max_length)
-        if split_pos <= 0:
-            split_pos = max_length
-
-        chunks.append(text[:split_pos])
-        rest = text[split_pos:]
-        if rest.startswith("\n"):
-            rest = rest[1:]
-        elif rest.startswith(" "):
-            rest = rest[1:]
-        text = rest
-
-    return chunks
-
-
-def _fallback_notification_text(text: str, max_len: int = SLACK_MESSAGE_MAX_LENGTH) -> str:
-    """Plain `text` for chat.postMessage (notifications, search); keep under Slack limits."""
-    if len(text) <= max_len:
-        return text
-    return text[: max_len - 1] + "…"
-
-
-def _say_markdown_chunks(say, chunks: list[str], thread_ts: str) -> None:
-    """Post assistant content using Block Kit `markdown` blocks (Slack renders GFM-style Markdown)."""
-    for chunk in chunks:
-        say(
-            text=_fallback_notification_text(chunk),
-            blocks=[{"type": "markdown", "text": chunk}],
-            thread_ts=thread_ts,
-        )
 
 
 def _add_reaction(client, channel: str, timestamp: str, name: str) -> None:
@@ -310,8 +269,7 @@ def _handle_mention(ack, event, say, client, cursor_client: CursorClient):
                 thread_store.set_last_message_id(thread_ts, latest_msg.id)
                 thread_store.set_last_message_fingerprint(thread_ts, current_fingerprint)
 
-                chunks = _split_message(latest_msg.text, max_length=SLACK_MARKDOWN_BLOCK_TEXT_MAX)
-                _say_markdown_chunks(say, chunks, thread_ts)
+                _slack_md.say_markdown_text(say, latest_msg.text, thread_ts)
 
                 _remove_reaction(client, channel, event_ts, "eyes")
                 _add_reaction(client, channel, event_ts, "white_check_mark")

--- a/src/bot/reporter.py
+++ b/src/bot/reporter.py
@@ -101,7 +101,7 @@ def generate_daily_report(
     # Post to Slack if not dry run
     if not dry_run and client is not None:
         try:
-            post_result = client.post_message(payload.formatted_text)
+            post_result = client.post_message_markdown(payload.formatted_text)
             logger.info("Posted daily report to Slack")
             logger.info(f"Post result: {post_result}")
         except Exception as e:
@@ -254,7 +254,7 @@ def generate_weekly_report(
     # Post to Slack if not dry run
     if not dry_run and client is not None:
         try:
-            client.post_message(payload.formatted_text)
+            client.post_message_markdown(payload.formatted_text)
 
             for item in payload.upload_plan:
                 client.upload_file(item.path, item.title)

--- a/src/slack/client.py
+++ b/src/slack/client.py
@@ -16,6 +16,39 @@ from src.utils.retry import is_temporary_error, retry_with_backoff
 
 logger = get_logger(__name__)
 
+# Notifications / search preview (`text`); Block Kit markdown body uses a higher limit (see kashiwaas).
+SLACK_MESSAGE_MAX_LENGTH = 4000
+SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12000
+
+
+def _fallback_notification_text(text: str, max_len: int = SLACK_MESSAGE_MAX_LENGTH) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _split_text_for_markdown_blocks(text: str, max_length: int = SLACK_MARKDOWN_BLOCK_TEXT_MAX) -> List[str]:
+    if len(text) <= max_length:
+        return [text]
+    chunks: List[str] = []
+    rest = text
+    while rest:
+        if len(rest) <= max_length:
+            chunks.append(rest)
+            break
+        split_pos = rest.rfind("\n", 0, max_length)
+        if split_pos == -1:
+            split_pos = rest.rfind(" ", 0, max_length)
+        if split_pos <= 0:
+            split_pos = max_length
+        chunks.append(rest[:split_pos])
+        rest = rest[split_pos:]
+        if rest.startswith("\n"):
+            rest = rest[1:]
+        elif rest.startswith(" "):
+            rest = rest[1:]
+    return chunks
+
 
 class SlackClient:
     """
@@ -320,6 +353,39 @@ class SlackClient:
 
         except SlackApiError as e:
             logger.error(f"Failed to post message: {e}")
+            self._handle_rate_limit(e)
+            raise
+
+    @retry_with_backoff(
+        max_retries=3,
+        initial_backoff=1.0,
+        backoff_factor=2.0,
+        exceptions_to_retry=[SlackApiError],
+        should_retry_fn=is_temporary_error,
+        on_retry_callback=lambda retries, e, wait_time: logger.warning(
+            f"Retrying post_message_markdown after error: {e}"
+        ),
+    )
+    def post_message_markdown(self, text: str, thread_ts: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Post using Block Kit `markdown` blocks (GFM-style), same approach as KashiwaaS bot.
+        Avoids plain-text escaping of `<` in mrkdwn links.
+        """
+        try:
+            chunks = _split_text_for_markdown_blocks(text)
+            blocks = [{"type": "markdown", "text": chunk} for chunk in chunks]
+            params: Dict[str, Any] = {
+                "channel": self.channel_id,
+                "text": _fallback_notification_text(text),
+                "blocks": blocks,
+            }
+            if thread_ts is not None:
+                params["thread_ts"] = thread_ts
+            response = self.client.chat_postMessage(**params)
+            logger.info(f"Markdown message posted to channel {self.channel_id}")
+            return response
+        except SlackApiError as e:
+            logger.error(f"Failed to post markdown message: {e}")
             self._handle_rate_limit(e)
             raise
 

--- a/src/slack/client.py
+++ b/src/slack/client.py
@@ -10,44 +10,15 @@ from typing import Any, Dict, Generator, List, Optional
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from src.slack.markdown_blocks import (
+    fallback_notification_text,
+    markdown_blocks_for_text,
+)
 from src.slack.message import SlackMessage
 from src.utils.logger import get_logger
 from src.utils.retry import is_temporary_error, retry_with_backoff
 
 logger = get_logger(__name__)
-
-# Notifications / search preview (`text`); Block Kit markdown body uses a higher limit (see kashiwaas).
-SLACK_MESSAGE_MAX_LENGTH = 4000
-SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12000
-
-
-def _fallback_notification_text(text: str, max_len: int = SLACK_MESSAGE_MAX_LENGTH) -> str:
-    if len(text) <= max_len:
-        return text
-    return text[: max_len - 1] + "…"
-
-
-def _split_text_for_markdown_blocks(text: str, max_length: int = SLACK_MARKDOWN_BLOCK_TEXT_MAX) -> List[str]:
-    if len(text) <= max_length:
-        return [text]
-    chunks: List[str] = []
-    rest = text
-    while rest:
-        if len(rest) <= max_length:
-            chunks.append(rest)
-            break
-        split_pos = rest.rfind("\n", 0, max_length)
-        if split_pos == -1:
-            split_pos = rest.rfind(" ", 0, max_length)
-        if split_pos <= 0:
-            split_pos = max_length
-        chunks.append(rest[:split_pos])
-        rest = rest[split_pos:]
-        if rest.startswith("\n"):
-            rest = rest[1:]
-        elif rest.startswith(" "):
-            rest = rest[1:]
-    return chunks
 
 
 class SlackClient:
@@ -372,11 +343,10 @@ class SlackClient:
         Avoids plain-text escaping of `<` in mrkdwn links.
         """
         try:
-            chunks = _split_text_for_markdown_blocks(text)
-            blocks = [{"type": "markdown", "text": chunk} for chunk in chunks]
+            blocks = markdown_blocks_for_text(text)
             params: Dict[str, Any] = {
                 "channel": self.channel_id,
-                "text": _fallback_notification_text(text),
+                "text": fallback_notification_text(text),
                 "blocks": blocks,
             }
             if thread_ts is not None:

--- a/src/slack/markdown_blocks.py
+++ b/src/slack/markdown_blocks.py
@@ -1,0 +1,67 @@
+"""
+Shared Block Kit markdown helpers (KashiwaaS bot, SlackClient reports).
+
+https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
+"""
+
+from typing import Any, Callable, Dict, List
+
+SLACK_MESSAGE_MAX_LENGTH = 4000
+SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12000
+
+
+def split_slack_message_text(text: str, max_length: int = SLACK_MESSAGE_MAX_LENGTH) -> List[str]:
+    """Split long text at newlines/spaces for Slack message or markdown-block limits."""
+    if len(text) <= max_length:
+        return [text]
+
+    chunks: List[str] = []
+    rest = text
+    while rest:
+        if len(rest) <= max_length:
+            chunks.append(rest)
+            break
+
+        split_pos = rest.rfind("\n", 0, max_length)
+        if split_pos == -1:
+            split_pos = rest.rfind(" ", 0, max_length)
+        if split_pos <= 0:
+            split_pos = max_length
+
+        chunks.append(rest[:split_pos])
+        rest = rest[split_pos:]
+        if rest.startswith("\n"):
+            rest = rest[1:]
+        elif rest.startswith(" "):
+            rest = rest[1:]
+
+    return chunks
+
+
+def fallback_notification_text(text: str, max_len: int = SLACK_MESSAGE_MAX_LENGTH) -> str:
+    """Plain `text` for chat.postMessage (notifications, search); keep under Slack limits."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def markdown_blocks_for_text(text: str, max_chunk: int = SLACK_MARKDOWN_BLOCK_TEXT_MAX) -> List[Dict[str, Any]]:
+    """Block Kit `markdown` blocks for full body (single post, multiple blocks if needed)."""
+    chunks = split_slack_message_text(text, max_chunk)
+    return [{"type": "markdown", "text": chunk} for chunk in chunks]
+
+
+def say_markdown_chunks(say: Callable[..., None], chunks: List[str], thread_ts: str) -> None:
+    """One chat.postMessage per chunk (Bolt `say` in a thread)."""
+    for chunk in chunks:
+        say(
+            text=fallback_notification_text(chunk),
+            blocks=[{"type": "markdown", "text": chunk}],
+            thread_ts=thread_ts,
+        )
+
+
+def say_markdown_text(say: Callable[..., None], text: str, thread_ts: str) -> None:
+    """Split long assistant text then post with :func:`say_markdown_chunks`."""
+    chunks = split_slack_message_text(text, SLACK_MARKDOWN_BLOCK_TEXT_MAX)
+    say_markdown_chunks(say, chunks, thread_ts)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -182,3 +182,21 @@ class TestSlackClientMock:
         mock_client.conversations_history.assert_called_once()
         # Verify thread replies were not fetched (test data has no thread)
         mock_client.conversations_replies.assert_not_called()
+
+    @patch("src.slack.client.WebClient")
+    def test_post_message_markdown_uses_blocks(self, mock_web_client):
+        mock_client = MagicMock()
+        mock_web_client.return_value = mock_client
+        mock_client.chat_postMessage.return_value = {"ok": True, "ts": "1.0"}
+
+        client = SlackClient(token="xoxb-test-token", channel_id="C12345678")
+        body = "Hello\n\n1. [label](https://example.com) (2 reactions)"
+        client.post_message_markdown(body)
+
+        mock_client.chat_postMessage.assert_called_once()
+        call_kw = mock_client.chat_postMessage.call_args[1]
+        assert call_kw["channel"] == "C12345678"
+        assert call_kw["text"] == body
+        assert len(call_kw["blocks"]) == 1
+        assert call_kw["blocks"][0]["type"] == "markdown"
+        assert call_kw["blocks"][0]["text"] == body

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -10,6 +10,7 @@ import pytest
 
 from src.es_client.slack_doc import slack_message_to_doc
 from src.slack.client import SlackClient
+from src.slack.markdown_blocks import markdown_blocks_for_text
 from src.slack.message import SlackMessage, SlackReaction
 
 
@@ -200,3 +201,9 @@ class TestSlackClientMock:
         assert len(call_kw["blocks"]) == 1
         assert call_kw["blocks"][0]["type"] == "markdown"
         assert call_kw["blocks"][0]["text"] == body
+
+    def test_markdown_blocks_for_text_matches_post_message_markdown(self):
+        body = "Hello\n\n1. [label](https://example.com) (2 reactions)"
+        blocks = markdown_blocks_for_text(body)
+        assert len(blocks) == 1
+        assert blocks[0] == {"type": "markdown", "text": body}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Weekly Report（および Daily Report）が `chat_postMessage` のプレーン `text` のみで送られていたため、Slack 側で `<` がエスケープされ、リンクが `&lt;...&gt;` のように表示されていました。

## 変更内容

- `SlackClient.post_message_markdown` で Block Kit の `markdown` ブロックを使用（KashiwaaS と同じ方針）
- Top Posts を GFM の `[label](url)` に変更；ラベル内の `[` / `]` は空白に置換
- **共通化:** `src/slack/markdown_blocks.py` に分割・通知用 `text`・ブロック組み立て・Bolt 用 `say_markdown_chunks` / `say_markdown_text` を集約。`SlackClient` と KashiwaaS の双方がここを利用（テスト向けに `kashiwaas` から定数・エイリアスを再エクスポート）
- テスト: `post_message_markdown`、`markdown_blocks_for_text` の整合

## テスト

`pytest` および `black` / `isort` / `flake8` を実行済みです。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7470bd34-db97-4f32-85b9-fea8540c76e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7470bd34-db97-4f32-85b9-fea8540c76e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/takak2166/kashiwaas/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
