### PR TITLE
CI: Use make lint and make test without poetry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: poetry install --no-interaction --no-ansi
 
       - name: Run linting
-        run: poetry run make lint
+        run: make lint
         env:
           # Minimal env so load_config() does not get None for required fields when tests import app modules
           SLACK_API_TOKEN: ""
@@ -37,7 +37,7 @@ jobs:
           SELENIUM_HOST: ""
 
       - name: Run tests
-        run: poetry run make test
+        run: make test
         env:
           SLACK_API_TOKEN: ""
           SLACK_CHANNEL_ID: ""

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,7 +37,7 @@
 ## Local and CI
 
 - Local: `make test` (`pytest`), `make lint` (`ruff`) — [Makefile](../Makefile)
-- PRs to `main`: GitHub Actions runs `lint_and_test` (`poetry run make lint` / `make test`) and `dry-run` (Docker Compose) — [.github/workflows/ci.yml](../.github/workflows/ci.yml)
+- PRs to `main`: GitHub Actions runs `lint_and_test` (`make lint` / `make test`) and `dry-run` (Docker Compose) — [.github/workflows/ci.yml](../.github/workflows/ci.yml)
 
 ## Cursor agent hooks
 


### PR DESCRIPTION
## 概要

CI の lint/test とドキュメントで、`poetry run make` ではなく `make lint` / `make test` を直接呼ぶようにし、ローカルと同じ実行形に揃えた。

## 主な変更

- `.github/workflows/ci.yml`: `lint_and_test` ジョブの `run` を `make lint` / `make test` に変更
- `docs/testing.md`: PR 向け説明を同じ表記に更新

## 確認

- [ ] `make test`
- [ ] `make lint`

## Reference

- Notion: None（ブランチ名にチケット ID なし）
- ADR: None

## 補足

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/takak2166/kashiwaas/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
