### PR TITLE
Fix Kibana import IDs to match Elasticsearch index naming

### DIFF
--- a/scripts/import_kibana_objects.py
+++ b/scripts/import_kibana_objects.py
@@ -2,12 +2,17 @@
 import argparse
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict
 
 import jinja2
 import requests
 from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.es_client.index import get_index_name
 
 # Configure logger
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -68,15 +73,19 @@ def main():
         # Load environment variables
         env = load_env()
 
-        # Set variables
-        env["index_pattern_id"] = f"slack-{env['SLACK_CHANNEL_NAME']}"
-        env["index_pattern_title"] = env["index_pattern_id"]
-        env["lens_id"] = f"tagcloud-{env['SLACK_CHANNEL_NAME']}"
+        # Match Elasticsearch index naming (src.es_client.index.get_index_name)
+        channel = env["SLACK_CHANNEL_NAME"]
+        index_name = get_index_name(channel)
+        slug = index_name.removeprefix("slack-")
+
+        env["index_pattern_id"] = index_name
+        env["index_pattern_title"] = index_name
+        env["lens_id"] = f"tagcloud-{slug}"
         env["lens_title"] = "tag cloud"
-        env["layer_id"] = f"layer-{env['SLACK_CHANNEL_NAME']}"
-        env["dashboard_id"] = f"{env['SLACK_CHANNEL_NAME']}-weekly"
-        env["dashboard_title"] = f"{env['SLACK_CHANNEL_NAME']}'s Dashboard"
-        env["dashboard_description"] = f"message statistics dashboard of {env['SLACK_CHANNEL_NAME']}"
+        env["layer_id"] = f"layer-{slug}"
+        env["dashboard_id"] = f"{slug}-weekly"
+        env["dashboard_title"] = f"{channel}'s Dashboard"
+        env["dashboard_description"] = f"message statistics dashboard of {channel}"
 
         # Set template directory
         templates_dir = Path(__file__).parent.parent / "kibana" / "templates"


### PR DESCRIPTION
## 概要

Kibana インポート時に Data View の ID が `get_index_name()` と不一致になり、チャンネル名にアンダースコア等があると実データのインデックスと可視化の参照がずれる問題を防ぐ。

## 主な変更

- scripts/import_kibana_objects.py: `get_index_name()` と同じ名前で `index_pattern_id` / `index_pattern_title` を設定し、Lens・Dashboard のオブジェクト ID も正規化スラッグで統一

## 確認

- [ ] `make test`
- [ ] `make lint`

## 参考

- Notion: None（ブランチ名にチケット ID が含まれないため）
- ADR: None

<!-- 任意: 手動確認・デプロイ影響・ロールバック方針
## 補足

N/A
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/takak2166/kashiwaas/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
