### PR TITLE
Stabilize Cursor assistant reply text after FINISHED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ CURSOR_POLL_INTERVAL=5
 CURSOR_POLL_TIMEOUT=600
 # Model: explicit ID (e.g. composer-2), or Auto / default / empty to use API default. See GET https://api.cursor.com/v0/models for available IDs.
 CURSOR_MODEL=composer-2
+# After FINISHED: retry conversation GET until the latest assistant message id advances (eventual consistency).
+CURSOR_CONVERSATION_RETRY_MAX_RETRIES=4
+CURSOR_CONVERSATION_RETRY_DELAY_SECONDS=1.5
+# Then poll until assistant text is unchanged for N consecutive reads (interval seconds apart, max extra rounds). Reduces partial replies right after FINISHED.
+CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS=1.0
+CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES=3
+CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS=60
 
 ELASTICSEARCH_HOST=http://elasticsearch:9200
 ELASTICSEARCH_USER=elastic

--- a/src/bot/kashiwaas.py
+++ b/src/bot/kashiwaas.py
@@ -128,6 +128,9 @@ def create_app(cfg: AppConfig) -> App:
         model=cfg.cursor.model,
         conversation_retry_max_retries=cfg.cursor.conversation_retry_max_retries,
         conversation_retry_delay_seconds=cfg.cursor.conversation_retry_delay_seconds,
+        conversation_text_stabilize_interval_seconds=cfg.cursor.conversation_text_stabilize_interval_seconds,
+        conversation_text_stabilize_required_matches=cfg.cursor.conversation_text_stabilize_required_matches,
+        conversation_text_stabilize_max_rounds=cfg.cursor.conversation_text_stabilize_max_rounds,
     )
     thread_store = ThreadStore(cfg.valkey)
 

--- a/src/bot/kashiwaas.py
+++ b/src/bot/kashiwaas.py
@@ -277,7 +277,6 @@ def _handle_mention(ack, event, say, client, cursor_client: CursorClient, thread
 
                 if _dup():
                     max_retries = cursor_client.conversation_retry_max_retries
-                    delay_seconds = cursor_client.conversation_retry_delay_seconds
                     for attempt in range(max_retries):
                         logger.info(
                             "Duplicate assistant message detected; retrying conversation fetch "
@@ -286,9 +285,10 @@ def _handle_mention(ack, event, say, client, cursor_client: CursorClient, thread
                                 f"event_ts={event_ts}, msg_id={latest_msg.id})"
                             )
                         )
-                        if attempt > 0:
-                            time.sleep(delay_seconds * (2 ** (attempt - 1)))
-                        refreshed = cursor_client.get_conversation(result.agent_id)
+                        refreshed = cursor_client.get_conversation_after_complete(
+                            result.agent_id,
+                            expected_previous_message_id=latest_msg.id,
+                        )
                         latest = cursor_client.get_latest_assistant_message_obj(refreshed)
                         if not latest:
                             break

--- a/src/cursor/client.py
+++ b/src/cursor/client.py
@@ -74,6 +74,9 @@ class CursorClient:
         model: Optional[str] = None,
         conversation_retry_max_retries: int = 4,
         conversation_retry_delay_seconds: float = 1.5,
+        conversation_text_stabilize_interval_seconds: float = 1.0,
+        conversation_text_stabilize_required_matches: int = 3,
+        conversation_text_stabilize_max_rounds: int = 60,
     ):
         self.api_key = api_key
         self.source_repository = source_repository
@@ -84,6 +87,9 @@ class CursorClient:
         self.model = model
         self.conversation_retry_max_retries = conversation_retry_max_retries
         self.conversation_retry_delay_seconds = conversation_retry_delay_seconds
+        self.conversation_text_stabilize_interval_seconds = conversation_text_stabilize_interval_seconds
+        self.conversation_text_stabilize_required_matches = conversation_text_stabilize_required_matches
+        self.conversation_text_stabilize_max_rounds = conversation_text_stabilize_max_rounds
 
         encoded = b64encode(f"{api_key}:".encode()).decode()
         self.headers = {
@@ -172,6 +178,37 @@ class CursorClient:
             )
         return messages
 
+    def _stabilize_conversation_assistant_text(self, agent_id: str, messages: List[AgentMessage]) -> List[AgentMessage]:
+        """
+        Poll conversation until the latest assistant ``text`` is unchanged for
+        ``conversation_text_stabilize_required_matches`` consecutive fetches
+        (after ``conversation_text_stabilize_interval_seconds`` between fetches),
+        or ``conversation_text_stabilize_max_rounds`` additional polls elapse.
+        """
+        required = self.conversation_text_stabilize_required_matches
+        if required < 2:
+            return messages
+        latest = self.get_latest_assistant_message_obj(messages)
+        if latest is None:
+            return messages
+        prev_text = latest.text
+        stable_count = 1
+        interval = self.conversation_text_stabilize_interval_seconds
+        for _ in range(self.conversation_text_stabilize_max_rounds):
+            if stable_count >= required:
+                return messages
+            time.sleep(interval)
+            messages = self.get_conversation(agent_id)
+            latest = self.get_latest_assistant_message_obj(messages)
+            if latest is None:
+                return messages
+            if latest.text == prev_text:
+                stable_count += 1
+            else:
+                stable_count = 1
+                prev_text = latest.text
+        return messages
+
     def get_conversation_after_complete(
         self,
         agent_id: str,
@@ -188,21 +225,27 @@ class CursorClient:
         answer (API eventual consistency). Uses exponential backoff between
         retries (delay_seconds * 2^attempt). Uses conversation_retry_max_retries
         and conversation_retry_delay_seconds from the client when not overridden.
+
+        Then polls until the latest assistant message text is stable for
+        ``conversation_text_stabilize_required_matches`` consecutive reads
+        (``conversation_text_stabilize_interval_seconds`` apart), so partially
+        materialized replies are less likely to be returned right after FINISHED.
         """
         max_retries = max_retries if max_retries is not None else self.conversation_retry_max_retries
         delay_seconds = delay_seconds if delay_seconds is not None else self.conversation_retry_delay_seconds
         if max_retries < 1:
-            return self.get_conversation(agent_id)
+            messages = self.get_conversation(agent_id)
+            return self._stabilize_conversation_assistant_text(agent_id, messages)
         for attempt in range(max_retries):
             messages = self.get_conversation(agent_id)
             latest = self.get_latest_assistant_message_obj(messages)
             if expected_previous_message_id is None or latest is None:
-                return messages
+                return self._stabilize_conversation_assistant_text(agent_id, messages)
             if latest.id != expected_previous_message_id:
-                return messages
+                return self._stabilize_conversation_assistant_text(agent_id, messages)
             if attempt < max_retries - 1:
                 time.sleep(delay_seconds * (2**attempt))
-        return messages
+        return self._stabilize_conversation_assistant_text(agent_id, messages)
 
     def send_followup(self, agent_id: str, prompt: str) -> None:
         """Send a follow-up prompt to an existing agent."""

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -78,6 +78,9 @@ class CursorConfig:
     model: Optional[str] = "composer-2"
     conversation_retry_max_retries: int = 4
     conversation_retry_delay_seconds: float = 1.5
+    conversation_text_stabilize_interval_seconds: float = 1.0
+    conversation_text_stabilize_required_matches: int = 3
+    conversation_text_stabilize_max_rounds: int = 60
 
 
 @dataclass(frozen=True)
@@ -169,6 +172,9 @@ def load_config(env: Mapping[str, str] | None = None) -> AppConfig:
 
     conv_max = _get_int(e, "CURSOR_CONVERSATION_RETRY_MAX_RETRIES", 4)
     conv_delay = _get_float(e, "CURSOR_CONVERSATION_RETRY_DELAY_SECONDS", 1.5)
+    conv_stab_interval = _get_float(e, "CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS", 1.0)
+    conv_stab_matches = _get_int(e, "CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES", 3)
+    conv_stab_max = _get_int(e, "CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS", 60)
 
     valkey_url = _get_str(e, "VALKEY_URL", "redis://localhost:6379/0") or "redis://localhost:6379/0"
     valkey_ttl = _get_int(e, "VALKEY_THREAD_TTL_SECONDS", DEFAULT_VALKEY_THREAD_TTL_SECONDS)
@@ -214,6 +220,9 @@ def load_config(env: Mapping[str, str] | None = None) -> AppConfig:
             model=_get_str(e, "CURSOR_MODEL", "composer-2"),
             conversation_retry_max_retries=conv_max,
             conversation_retry_delay_seconds=conv_delay,
+            conversation_text_stabilize_interval_seconds=conv_stab_interval,
+            conversation_text_stabilize_required_matches=conv_stab_matches,
+            conversation_text_stabilize_max_rounds=conv_stab_max,
         ),
         bot=BotConfig(
             app_token=_get_str(e, "SLACK_APP_TOKEN"),

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -175,6 +175,12 @@ def load_config(env: Mapping[str, str] | None = None) -> AppConfig:
     conv_stab_interval = _get_float(e, "CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS", 1.0)
     conv_stab_matches = _get_int(e, "CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES", 3)
     conv_stab_max = _get_int(e, "CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS", 60)
+    if conv_stab_interval < 0:
+        raise ConfigError("CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS must be >= 0")
+    if conv_stab_matches < 1:
+        raise ConfigError("CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES must be >= 1")
+    if conv_stab_max < 1:
+        raise ConfigError("CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS must be >= 1")
 
     valkey_url = _get_str(e, "VALKEY_URL", "redis://localhost:6379/0") or "redis://localhost:6379/0"
     valkey_ttl = _get_int(e, "VALKEY_THREAD_TTL_SECONDS", DEFAULT_VALKEY_THREAD_TTL_SECONDS)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,21 @@ def test_load_config_cursor_text_stabilize_env() -> None:
     assert cfg.cursor.conversation_text_stabilize_max_rounds == 10
 
 
+def test_load_config_cursor_text_stabilize_interval_negative_raises() -> None:
+    with pytest.raises(ConfigError, match="CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS must be >= 0"):
+        load_config({"CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS": "-0.1"})
+
+
+def test_load_config_cursor_text_stabilize_required_matches_below_one_raises() -> None:
+    with pytest.raises(ConfigError, match="CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES must be >= 1"):
+        load_config({"CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES": "0"})
+
+
+def test_load_config_cursor_text_stabilize_max_rounds_below_one_raises() -> None:
+    with pytest.raises(ConfigError, match="CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS must be >= 1"):
+        load_config({"CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS": "0"})
+
+
 def test_load_config_valkey_ttl_negative_raises_config_error() -> None:
     with pytest.raises(ConfigError, match="VALKEY_THREAD_TTL_SECONDS must be >= 0"):
         load_config({"VALKEY_THREAD_TTL_SECONDS": "-1"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,19 @@ def test_load_config_invalid_float_raises_config_error() -> None:
         load_config({"CURSOR_CONVERSATION_RETRY_DELAY_SECONDS": "x"})
 
 
+def test_load_config_cursor_text_stabilize_env() -> None:
+    cfg = load_config(
+        {
+            "CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS": "2.5",
+            "CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES": "5",
+            "CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS": "10",
+        }
+    )
+    assert cfg.cursor.conversation_text_stabilize_interval_seconds == 2.5
+    assert cfg.cursor.conversation_text_stabilize_required_matches == 5
+    assert cfg.cursor.conversation_text_stabilize_max_rounds == 10
+
+
 def test_load_config_valkey_ttl_negative_raises_config_error() -> None:
     with pytest.raises(ConfigError, match="VALKEY_THREAD_TTL_SECONDS must be >= 0"):
         load_config({"VALKEY_THREAD_TTL_SECONDS": "-1"})

--- a/tests/test_cursor_client.py
+++ b/tests/test_cursor_client.py
@@ -23,6 +23,7 @@ def cursor_client():
         source_ref="main",
         poll_interval=0.01,
         poll_timeout=0.05,
+        conversation_text_stabilize_required_matches=1,
     )
 
 
@@ -358,6 +359,55 @@ class TestCursorClient:
         with patch.object(cursor_client, "get_conversation", return_value=messages):
             result = cursor_client.get_conversation_after_complete("agent_1", max_retries=0)
         assert result == messages
+
+    @patch("src.cursor.client.time.sleep")
+    def test_get_conversation_after_complete_stabilizes_assistant_text(self, mock_sleep):
+        """Poll until latest assistant text matches three consecutive fetches."""
+        partial = [
+            AgentMessage(id="1", type="user_message", text="q"),
+            AgentMessage(id="m1", type="assistant_message", text="partial"),
+        ]
+        full = [
+            AgentMessage(id="1", type="user_message", text="q"),
+            AgentMessage(id="m1", type="assistant_message", text="full answer"),
+        ]
+        client = CursorClient(
+            api_key="k",
+            source_repository="https://github.com/t/r",
+            conversation_text_stabilize_interval_seconds=0.01,
+            conversation_text_stabilize_required_matches=3,
+            conversation_text_stabilize_max_rounds=20,
+        )
+        with patch.object(
+            client,
+            "get_conversation",
+            side_effect=[partial, full, full, full],
+        ):
+            result = client.get_conversation_after_complete("agent_1", expected_previous_message_id="prev")
+        assert result[1].text == "full answer"
+        assert mock_sleep.call_count == 3
+
+    @patch("src.cursor.client.time.sleep")
+    def test_stabilize_stops_after_max_rounds(self, mock_sleep):
+        """When text never stabilizes, return the last snapshot after max_rounds."""
+        a = [
+            AgentMessage(id="1", type="user_message", text="q"),
+            AgentMessage(id="m", type="assistant_message", text="a"),
+        ]
+        b = [
+            AgentMessage(id="1", type="user_message", text="q"),
+            AgentMessage(id="m", type="assistant_message", text="b"),
+        ]
+        client = CursorClient(
+            api_key="k",
+            source_repository="https://github.com/t/r",
+            conversation_text_stabilize_interval_seconds=0.01,
+            conversation_text_stabilize_required_matches=3,
+            conversation_text_stabilize_max_rounds=2,
+        )
+        with patch.object(client, "get_conversation", side_effect=[a, b, b]):
+            result = client.get_conversation_after_complete("agent_1", expected_previous_message_id="prev")
+        assert result[1].text == "b"
 
     def test_get_latest_assistant_message_obj(self, cursor_client):
         # Chronological order: last assistant is latest

--- a/tests/test_kashiwaas.py
+++ b/tests/test_kashiwaas.py
@@ -673,6 +673,7 @@ class TestThreadLocks:
         say = MagicMock()
         client = MagicMock()
         cursor_client = MagicMock()
+        cursor_client.conversation_retry_max_retries = 4
         cursor_client.followup.return_value = AgentResult(
             agent_id="agent_1",
             status=AgentStatus.FINISHED,
@@ -690,6 +691,7 @@ class TestThreadLocks:
         _handle_mention(ack, event, say, client, cursor_client, mock_store)
 
         say.assert_called()
+        cursor_client.get_conversation_after_complete.assert_called()
 
     @patch("src.bot.kashiwaas._is_duplicate_event", return_value=False)
     @patch("src.bot.kashiwaas.threading.Thread")
@@ -725,12 +727,14 @@ class TestThreadLocks:
         say = MagicMock()
         client = MagicMock()
         cursor_client = MagicMock()
+        cursor_client.conversation_retry_max_retries = 2
         cursor_client.followup.return_value = AgentResult(
             agent_id="agent_1",
             status=AgentStatus.FINISHED,
             messages=[AgentMessage(id="m_dup", type="assistant_message", text="duplicate")],
         )
         cursor_client.get_latest_assistant_message_obj.side_effect = [
+            AgentMessage(id="m_dup", type="assistant_message", text="duplicate"),
             AgentMessage(id="m_dup", type="assistant_message", text="duplicate"),
             AgentMessage(id="m_dup", type="assistant_message", text="duplicate"),
         ]
@@ -742,3 +746,4 @@ class TestThreadLocks:
 
         say.assert_called_once()
         assert "same response content" in say.call_args[1]["text"]
+        assert cursor_client.get_conversation_after_complete.call_count == 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`get_conversation_after_complete` で、最新アシスタントメッセージの解決（古いスナップショット対策の ID ベースのリトライを含む）のあと、`GET /v0/agents/{id}/conversation` を一定間隔で再取得し、最新アシスタントの `text` が **連続 3 回同一**になるまで待ちます。追加の取得は最大回数で打ち切り、最後に得たスナップショットを返します。

ステータスはすでに `FINISHED` だが会話本文だけが追いついていないときに起きやすい、**途中までの返信**を減らすための対策です。

## 設定（環境変数）

- `CURSOR_CONVERSATION_TEXT_STABILIZE_INTERVAL_SECONDS`（既定 `1.0`）
- `CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES`（既定 `3`）
- `CURSOR_CONVERSATION_TEXT_STABILIZE_MAX_ROUNDS`（既定 `60`）

`CURSOR_CONVERSATION_TEXT_STABILIZE_REQUIRED_MATCHES` を `1` にすると、本文の安定化ポーリングは行わず（既存の ID リトライのあと）最初の取得結果をそのまま返します。

## テスト

- 安定化ロジックと最大回数打ち切りのユニットテスト
- 上記環境変数の `load_config` のテスト
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5517f426-a305-4207-9b52-0ae23b5d18cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5517f426-a305-4207-9b52-0ae23b5d18cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/takak2166/kashiwaas/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
