### PR TITLE
fix(ci): Elasticsearch の準備完了まで待機して dry-run を安定化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,27 +86,35 @@ jobs:
 
       - name: Wait for services to be ready
         run: |
+          set -e
+          ready=0
           for i in {1..30}; do
-            if docker compose exec app curl -s http://elasticsearch:9200 > /dev/null; then
+            if docker compose exec -T app curl -fsS http://elasticsearch:9200/ >/dev/null 2>&1; then
               echo "Elasticsearch is available"
+              ready=1
               break
             fi
             echo "Elasticsearch is unavailable - sleeping... $i"
             sleep 2
           done
+          if [[ "$ready" -ne 1 ]]; then
+            echo "Elasticsearch did not become ready in time"
+            docker compose ps
+            exit 1
+          fi
 
       - name: Setup indices and dashboards
         run: |
-          docker compose exec app poetry run python scripts/setup_indices.py --channel dummy-channel
-          docker compose exec app poetry run python scripts/import_kibana_objects.py --overwrite
+          docker compose exec -T app poetry run python scripts/setup_indices.py --channel dummy-channel
+          docker compose exec -T app poetry run python scripts/import_kibana_objects.py --overwrite
 
       - name: Run fetch command with dummy data
-        run: docker compose exec app poetry run python -m src.cli fetch --dummy
+        run: docker compose exec -T app poetry run python -m src.cli fetch --dummy
 
       - name: Dry-run report command
         run: |
-          docker compose exec app poetry run python -m src.cli report --type daily --channel dummy-channel --dry-run
-          docker compose exec app poetry run python -m src.cli report --type weekly --channel dummy-channel --dry-run
+          docker compose exec -T app poetry run python -m src.cli report --type daily --channel dummy-channel --dry-run
+          docker compose exec -T app poetry run python -m src.cli report --type weekly --channel dummy-channel --dry-run
 
       - name: Clean up
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,33 @@ jobs:
       - name: Wait for services to be ready
         run: |
           set -e
-          ready=0
+          es_ready=0
           for i in {1..30}; do
             if docker compose exec -T app curl -fsS http://elasticsearch:9200/ >/dev/null 2>&1; then
               echo "Elasticsearch is available"
-              ready=1
+              es_ready=1
               break
             fi
             echo "Elasticsearch is unavailable - sleeping... $i"
             sleep 2
           done
-          if [[ "$ready" -ne 1 ]]; then
+          if [[ "$es_ready" -ne 1 ]]; then
             echo "Elasticsearch did not become ready in time"
+            docker compose ps
+            exit 1
+          fi
+          kbn_ready=0
+          for i in {1..45}; do
+            if docker compose exec -T app curl -fsS http://kibana:5601/api/status >/dev/null 2>&1; then
+              echo "Kibana is available"
+              kbn_ready=1
+              break
+            fi
+            echo "Kibana is unavailable - sleeping... $i"
+            sleep 5
+          done
+          if [[ "$kbn_ready" -ne 1 ]]; then
+            echo "Kibana did not become ready in time"
             docker compose ps
             exit 1
           fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     build: .
@@ -7,7 +6,8 @@ services:
     environment:
       - TZ=Asia/Tokyo
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
   
   elasticsearch:
     build: ./elasticsearch
@@ -19,6 +19,12 @@ services:
       - es_data:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:9200/ >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 40s
   
   kibana:
     image: docker.elastic.co/kibana/kibana:9.3.3
@@ -27,7 +33,8 @@ services:
     ports:
       - "5601:5601"
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
   
   chrome:
     image: selenium/standalone-chrome:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,12 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:5601/api/status >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 36
+      start_period: 120s
   
   chrome:
     image: selenium/standalone-chrome:latest

--- a/scripts/e2e_compose_smoke.sh
+++ b/scripts/e2e_compose_smoke.sh
@@ -65,6 +65,22 @@ if [[ "$ready" -ne 1 ]]; then
   exit 1
 fi
 
+kbn_ready=0
+for i in $(seq 1 45); do
+  if docker compose exec -T app curl -fsS http://kibana:5601/api/status >/dev/null 2>&1; then
+    echo "Kibana is available"
+    kbn_ready=1
+    break
+  fi
+  echo "Kibana is unavailable - sleeping... $i"
+  sleep 5
+done
+if [[ "$kbn_ready" -ne 1 ]]; then
+  echo "Kibana did not become ready in time"
+  docker compose ps
+  exit 1
+fi
+
 docker compose exec -T app poetry run python scripts/setup_indices.py --channel dummy-channel
 docker compose exec -T app poetry run python scripts/import_kibana_objects.py --overwrite
 

--- a/scripts/e2e_compose_smoke.sh
+++ b/scripts/e2e_compose_smoke.sh
@@ -49,14 +49,21 @@ docker compose up --build -d --wait
 docker compose cp .env app:/app/.env
 docker compose ps
 
+ready=0
 for i in $(seq 1 30); do
-  if docker compose exec -T app curl -s http://elasticsearch:9200 > /dev/null; then
+  if docker compose exec -T app curl -fsS http://elasticsearch:9200/ >/dev/null 2>&1; then
     echo "Elasticsearch is available"
+    ready=1
     break
   fi
   echo "Elasticsearch is unavailable - sleeping... $i"
   sleep 2
 done
+if [[ "$ready" -ne 1 ]]; then
+  echo "Elasticsearch did not become ready in time"
+  docker compose ps
+  exit 1
+fi
 
 docker compose exec -T app poetry run python scripts/setup_indices.py --channel dummy-channel
 docker compose exec -T app poetry run python scripts/import_kibana_objects.py --overwrite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

CI の `dry-run` で不安定だった要因を順に潰しています。

1. **Elasticsearch**: `ping` 失敗 — `curl -s` が 503 でも成功するため先に進んでいた。`healthcheck` + `curl -fsS` 待機で対応済み。
2. **Kibana**: `import_kibana_objects.py` が `Connection refused` — ES より Kibana の起動が遅いが、`--wait` が Kibana を待っていなかった。**Kibana に `healthcheck`（`/api/status`）** を追加し、CI / `e2e_compose_smoke.sh` でも **Kibana 待機**を追加。

## 変更ファイル

- `docker-compose.yml` — Kibana `healthcheck`
- `.github/workflows/ci.yml` — Kibana 待機ループ（最大約 3.75 分）
- `scripts/e2e_compose_smoke.sh` — 同上

## 検証

- `make lint` / `make test` 通過

## 備考

`docker compose up --wait` はヘルスチェック付きサービスのみ待つため、Kibana に healthcheck を付けるのが本筋です。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c00ad84d-0e4f-4e3c-858c-bd44d30028f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c00ad84d-0e4f-4e3c-858c-bd44d30028f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

