### PR TITLE
fix(docker): install Chromium for Plotly Kaleido weekly charts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ KIBANA_PASSWORD=changeme
 
 SELENIIUM_HOST=http://chrome:4444
 
+# Plotly weekly charts (Kaleido): path to Chromium/Chrome on the host. Docker image sets BROWSER_PATH=/usr/bin/chromium.
+# BROWSER_PATH=/usr/bin/chromium
+
 LOG_LEVEL=INFO
 LOG_RETENTION=7 days
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,16 @@ FROM python:3.14-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies (chromium: Plotly Kaleido / fig.write_image static export)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cron curl make\
-    # Dependencies for kaleido
+    cron curl make \
+    chromium \
+    fonts-liberation \
     libx11-6 libxcb1 libxext6 libxrender1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Kaleido (choreographer) uses this before PATH / bundled Chrome lookup
+ENV BROWSER_PATH=/usr/bin/chromium
 
 # Install Poetry
 RUN pip install poetry==2.3.4

--- a/src/bot/kashiwaas_mattermost.py
+++ b/src/bot/kashiwaas_mattermost.py
@@ -17,9 +17,9 @@ from dataclasses import dataclass, field, replace
 from typing import Any
 
 import websockets
-from websockets.asyncio.client import connect as ws_connect
 from mattermostdriver import Driver
 from mattermostdriver.websocket import Websocket as MattermostDriverWebsocket
+from websockets.asyncio.client import connect as ws_connect
 
 from src.bot.alerter import init_alerter
 from src.bot.cursor_reply import run_cursor_reply


### PR DESCRIPTION
## 概要

週次レポートの `fig.write_image`（Kaleido 1.x）が Chromium 系ブラウザを要求し、コンテナ内にブラウザが無いと失敗していました。アプリ用 Docker イメージに Chromium を入れ、choreographer が参照する `BROWSER_PATH` を設定します。

## 主な変更

- `Dockerfile`: `chromium` と `fonts-liberation` を追加、`ENV BROWSER_PATH=/usr/bin/chromium`
- `.env.example`: 非 Docker 実行時の任意 `BROWSER_PATH` を追記
- `src/bot/kashiwaas_mattermost.py`: ruff I001（import 並び）のみ修正

## 確認

- [x] `poetry run pytest`（164 passed, 3 skipped）
- [x] `poetry run ruff check .`

## デプロイ後

本番で app イメージの再ビルド・再デプロイが必要です（例: `docker compose build --no-cache app`）。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/takak2166/kashiwaas/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
